### PR TITLE
Implement Forgot Password screen UI and email validation

### DIFF
--- a/app/src/main/java/com/example/chatapp/presentation/forgetPasswordScreen/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/forgetPasswordScreen/ForgotPasswordScreen.kt
@@ -6,9 +6,139 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.navigation.NavController
 import org.koin.androidx.compose.koinViewModel
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material3.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.compose.rememberNavController
+import com.example.chatapp.ui.theme.ChatAppTheme
 
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ForgotPasswordScreen(navController: NavController, viewModel: ForgotPasswordViewModel = koinViewModel()) {
     val uiState by viewModel.uiState.collectAsState()
-    Text("Forgot Password Screen")
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Forgot Password") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground
+                )
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.background
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+
+
+            Text(
+                text = "Reset Your Password",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Enter the email address associated with your account and we'll send you a link to reset your password.",
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Email Input Field
+            OutlinedTextField(
+                value = uiState.email,
+                onValueChange = { viewModel.onEmailChange(it) },
+                label = { Text("Email Address") },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                leadingIcon = { Icon(Icons.Default.Email, contentDescription = "Email Icon") },
+                singleLine = true,
+                isError = uiState.error != null
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+
+            if (uiState.error != null) {
+                Text(
+                    text = uiState.error!!,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+            }
+
+            if (uiState.successMessage != null) {
+                Text(
+                    text = uiState.successMessage!!,
+                    color = Color(0xFF008000),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+            }
+
+            // Send Reset Link Button
+            Button(
+                onClick = {
+                    viewModel.sendPasswordResetEmail({})
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(50.dp),
+                shape = RoundedCornerShape(12.dp),
+                enabled = !uiState.isLoading,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF6A5AE0),
+                    contentColor = Color.White
+                )
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = Color.White,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text("Send Reset Link", fontSize = 16.sp)
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ForgotPasswordScreenPreview() {
+    ChatAppTheme {
+        ForgotPasswordScreen(navController = rememberNavController())
+    }
 }

--- a/app/src/main/java/com/example/chatapp/presentation/forgetPasswordScreen/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/forgetPasswordScreen/ForgotPasswordViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.chatapp.presentation.forgetPasswordScreen
 
+import android.util.Patterns
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.chatapp.domain.authUseCases.SendPasswordResetUseCase
@@ -14,6 +15,11 @@ class ForgotPasswordViewModel(private val sendPasswordResetUseCase: SendPassword
     fun onEmailChange(email: String) { _uiState.value = _uiState.value.copy(email = email) }
 
     fun sendPasswordResetEmail(onSuccess: () -> Unit) {
+
+        if (!Patterns.EMAIL_ADDRESS.matcher(uiState.value.email).matches()) {
+            _uiState.value = _uiState.value.copy(error = "Please enter a valid email address.")
+            return
+        }
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null, successMessage = null)
             sendPasswordResetUseCase(uiState.value.email).onSuccess {


### PR DESCRIPTION
This commit introduces the UI for the "Forgot Password" screen and adds email validation logic to the `ForgotPasswordViewModel`.

**ForgotPasswordScreen.kt:**
- Implements a Scaffold with a TopAppBar for navigation.
- Provides a text field for users to enter their email address.
- Displays error messages if the email is invalid or if the password reset fails.
- Shows a success message when the reset email is sent.
- Includes a "Send Reset Link" button with a loading indicator.
- Added a Preview for the screen.

**ForgotPasswordViewModel.kt:**
- Added email validation using `Patterns.EMAIL_ADDRESS.matcher()` before attempting to send the password reset email.
- Updates the `uiState` with an error message if the email format is invalid.