### PR TITLE
Implement Global Chat screen UI

### DIFF
--- a/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatScreen.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatScreen.kt
@@ -1,14 +1,222 @@
 package com.example.chatapp.presentation.globalChatScreen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.example.chatapp.domain.model.Message
+import com.example.chatapp.ui.theme.ChatAppTheme
 import org.koin.androidx.compose.koinViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GlobalChatScreen(
+    navController: NavController,
+    viewModel: GlobalChatViewModel = koinViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val listState = rememberLazyListState()
+
+    // Automatically scroll to the bottom when a new message arrives
+    LaunchedEffect(uiState.messages.size) {
+        if (uiState.messages.isNotEmpty()) {
+            listState.animateScrollToItem(uiState.messages.size - 1)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Global Chat") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            ChatInput(
+                message = uiState.currentMessage,
+                onMessageChange = viewModel::onMessageChange,
+                onSendClick = viewModel::sendMessage
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp),
+            contentPadding = PaddingValues(vertical = 8.dp)
+        ) {
+            items(uiState.messages) { message ->
+                MessageBubble(
+                    message = message,
+                    isFromCurrentUser = message.senderId == uiState.currentUserId
+                )
+            }
+        }
+    }
+}
 
 @Composable
-fun GlobalChatScreen(navController: NavController, viewModel: GlobalChatViewModel = koinViewModel()) {
-    val uiState by viewModel.uiState.collectAsState()
-    Text("Global Chat")
+fun MessageBubble(message: Message, isFromCurrentUser: Boolean) {
+    val boxAlignment = if (isFromCurrentUser) Alignment.CenterEnd else Alignment.CenterStart
+    val columnAlignment = if (isFromCurrentUser) Alignment.End else Alignment.Start
+    val backgroundColor = if (isFromCurrentUser) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    val textColor = if (isFromCurrentUser) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+    val bubbleShape = if (isFromCurrentUser) {
+        RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp, bottomStart = 16.dp, bottomEnd = 4.dp)
+    } else {
+        RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp, bottomStart = 4.dp, bottomEnd = 16.dp)
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        contentAlignment = boxAlignment
+    ) {
+        Column(horizontalAlignment = columnAlignment) {
+            Box(
+                modifier = Modifier
+                    .clip(bubbleShape)
+                    .background(backgroundColor)
+                    .padding(horizontal = 16.dp, vertical = 10.dp)
+            ) {
+                Text(text = message.text, color = textColor)
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = formatTimestamp(message.timestamp),
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.Gray
+            )
+        }
+    }
+}
+
+@Composable
+fun ChatInput(
+    message: String,
+    onMessageChange: (String) -> Unit,
+    onSendClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        OutlinedTextField(
+            value = message,
+            onValueChange = onMessageChange,
+            modifier = Modifier.weight(1f),
+            placeholder = { Text("Type your message here...") },
+            shape = RoundedCornerShape(24.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        IconButton(
+            onClick = onSendClick,
+            enabled = message.isNotBlank(),
+            colors = IconButtonDefaults.iconButtonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        ) {
+            Icon(Icons.Default.Send, contentDescription = "Send Message")
+        }
+    }
+}
+
+private fun formatTimestamp(timestamp: Long): String {
+    val sdf = SimpleDateFormat("h:mm a", Locale.getDefault())
+    return sdf.format(Date(timestamp))
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+fun GlobalChatScreenPreview() {
+    val previewMessages = listOf(
+        Message(senderId = "1", text = "Great! Should we add an emoji feature to the conversation screen?", timestamp = System.currentTimeMillis() - 200000),
+        Message(senderId = "2", text = "Good idea, but let's keep it simple at first. Focus on text messages initially.", timestamp = System.currentTimeMillis() - 100000),
+        Message(senderId = "1", text = "Okay, and if we want to test the screen, send me a wireframe.", timestamp = System.currentTimeMillis())
+    )
+
+    ChatAppTheme {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Global Chat") },
+                    navigationIcon = {
+                        IconButton(onClick = { }) {
+                            Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
+                        }
+                    }
+                )
+            },
+            bottomBar = {
+                ChatInput(message = "Hello there!", onMessageChange = {}, onSendClick = {})
+            }
+        ) { paddingValues ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(horizontal = 16.dp),
+                contentPadding = PaddingValues(vertical = 8.dp)
+            ) {
+                items(previewMessages) { message ->
+                    MessageBubble(
+                        message = message,
+                        isFromCurrentUser = message.senderId == "2" // "2" is the current user in this preview
+                    )
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This commit introduces the UI for the Global Chat screen.

The screen includes:
- A `TopAppBar` with a title and a back button.
- A `LazyColumn` to display chat messages. Messages are styled differently based on whether they are from the current user or another user. Timestamps are displayed below each message.
- A `ChatInput` section at the bottom, consisting of an `OutlinedTextField` for message input and an `IconButton` to send messages. The send button is enabled only when there is text in the input field.
- Automatic scrolling to the latest message when new messages arrive.
- A `formatTimestamp` utility function to display message times in a user-friendly format.
- A `@Preview` composable for UI development and testing.