### PR TITLE
Enhance Global Chat to display sender names and loading state

### DIFF
--- a/app/src/main/java/com/example/chatapp/di/presentationModule.kt
+++ b/app/src/main/java/com/example/chatapp/di/presentationModule.kt
@@ -16,5 +16,5 @@ val presentationModule = module {
     viewModel { UsersViewModel(get(), get()) }
     // We pass parameters to ChatViewModel from the navigation graph
     viewModel { params -> ChatViewModel(receiverId = params.get(), get(), get(), get()) }
-    viewModel { GlobalChatViewModel(get(), get(), get()) }
+    viewModel { GlobalChatViewModel(get(), get(), get(), get()) }
 }

--- a/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatScreen.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatScreen.kt
@@ -1,6 +1,7 @@
 package com.example.chatapp.presentation.globalChatScreen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -20,6 +21,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -37,6 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -82,28 +85,35 @@ fun GlobalChatScreen(
             )
         }
     ) { paddingValues ->
-        LazyColumn(
-            state = listState,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .padding(horizontal = 16.dp),
-            contentPadding = PaddingValues(vertical = 8.dp)
-        ) {
-            items(uiState.messages) { message ->
-                MessageBubble(
-                    message = message,
-                    isFromCurrentUser = message.senderId == uiState.currentUserId
-                )
+        if (uiState.isLoading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(horizontal = 16.dp),
+                contentPadding = PaddingValues(vertical = 8.dp)
+            ) {
+                items(uiState.messages) { uiMessage ->
+                    MessageBubble(
+                        uiMessage = uiMessage,
+                        isFromCurrentUser = uiMessage.message.senderId == uiState.currentUserId
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-fun MessageBubble(message: Message, isFromCurrentUser: Boolean) {
-    val boxAlignment = if (isFromCurrentUser) Alignment.CenterEnd else Alignment.CenterStart
-    val columnAlignment = if (isFromCurrentUser) Alignment.End else Alignment.Start
+fun MessageBubble(uiMessage: UiMessage, isFromCurrentUser: Boolean) {
+    val alignment = if (isFromCurrentUser) Alignment.End else Alignment.Start
+    val horizontalArrangement = if (isFromCurrentUser) Arrangement.End else Arrangement.Start
+
     val backgroundColor = if (isFromCurrentUser) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
     val textColor = if (isFromCurrentUser) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
     val bubbleShape = if (isFromCurrentUser) {
@@ -112,24 +122,33 @@ fun MessageBubble(message: Message, isFromCurrentUser: Boolean) {
         RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp, bottomStart = 4.dp, bottomEnd = 16.dp)
     }
 
-    Box(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp),
-        contentAlignment = boxAlignment
+        horizontalArrangement = horizontalArrangement
     ) {
-        Column(horizontalAlignment = columnAlignment) {
+        Column(horizontalAlignment = alignment) {
+            // Show sender's name for messages from other users
+            if (!isFromCurrentUser) {
+                Text(
+                    text = uiMessage.senderDisplayName,
+                    style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(bottom = 4.dp, start = 4.dp)
+                )
+            }
             Box(
                 modifier = Modifier
                     .clip(bubbleShape)
                     .background(backgroundColor)
                     .padding(horizontal = 16.dp, vertical = 10.dp)
             ) {
-                Text(text = message.text, color = textColor)
+                Text(text = uiMessage.message.text, color = textColor)
             }
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = formatTimestamp(message.timestamp),
+                text = formatTimestamp(uiMessage.message.timestamp),
                 style = MaterialTheme.typography.bodySmall,
                 color = Color.Gray
             )
@@ -181,10 +200,10 @@ private fun formatTimestamp(timestamp: Long): String {
 @Preview(showBackground = true)
 @Composable
 fun GlobalChatScreenPreview() {
-    val previewMessages = listOf(
-        Message(senderId = "1", text = "Great! Should we add an emoji feature to the conversation screen?", timestamp = System.currentTimeMillis() - 200000),
-        Message(senderId = "2", text = "Good idea, but let's keep it simple at first. Focus on text messages initially.", timestamp = System.currentTimeMillis() - 100000),
-        Message(senderId = "1", text = "Okay, and if we want to test the screen, send me a wireframe.", timestamp = System.currentTimeMillis())
+    val previewUiMessages = listOf(
+        UiMessage(Message(senderId = "1", text = "Great! Should we add an emoji feature to the conversation screen?", timestamp = System.currentTimeMillis() - 200000), "Alice"),
+        UiMessage(Message(senderId = "2", text = "Good idea, but let's keep it simple at first. Focus on text messages initially.", timestamp = System.currentTimeMillis() - 100000), "You"),
+        UiMessage(Message(senderId = "3", text = "Okay, and if we want to test the screen, send me a wireframe.", timestamp = System.currentTimeMillis()), "Bob")
     )
 
     ChatAppTheme {
@@ -210,10 +229,10 @@ fun GlobalChatScreenPreview() {
                     .padding(horizontal = 16.dp),
                 contentPadding = PaddingValues(vertical = 8.dp)
             ) {
-                items(previewMessages) { message ->
+                items(previewUiMessages) { uiMessage ->
                     MessageBubble(
-                        message = message,
-                        isFromCurrentUser = message.senderId == "2" // "2" is the current user in this preview
+                        uiMessage = uiMessage,
+                        isFromCurrentUser = uiMessage.message.senderId == "2" // "2" is the current user in this preview
                     )
                 }
             }

--- a/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatState.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatState.kt
@@ -3,9 +3,14 @@ package com.example.chatapp.presentation.globalChatScreen
 import com.example.chatapp.domain.model.Message
 
 data class GlobalChatState(
-    val messages: List<Message> = emptyList(),
+    val messages: List<UiMessage> = emptyList(),
     val currentMessage: String = "",
     val currentUserId: String = "",
     val isLoading: Boolean = false,
     val error: String? = null
+)
+
+data class UiMessage(
+    val message: Message,
+    val senderDisplayName: String
 )

--- a/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatViewModel.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatViewModel.kt
@@ -1,12 +1,15 @@
 package com.example.chatapp.presentation.globalChatScreen
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.chatapp.domain.authUseCases.GetCurrentUserUseCase
 import com.example.chatapp.domain.chatUseCases.GetGlobalMessagesUseCase
+import com.example.chatapp.domain.chatUseCases.GetUsersUseCase
 import com.example.chatapp.domain.chatUseCases.SendGlobalMessageUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -14,17 +17,54 @@ import kotlinx.coroutines.launch
 class GlobalChatViewModel(
     private val getGlobalMessagesUseCase: GetGlobalMessagesUseCase,
     private val sendGlobalMessageUseCase: SendGlobalMessageUseCase,
-    private val getCurrentUserUseCase: GetCurrentUserUseCase
+    private val getCurrentUserUseCase: GetCurrentUserUseCase,
+    private val getUsersUseCase: GetUsersUseCase
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(GlobalChatState())
     val uiState = _uiState.asStateFlow()
 
     init {
-        _uiState.value = _uiState.value.copy(currentUserId = getCurrentUserUseCase()?.uid ?: "")
-        getGlobalMessagesUseCase()
-            .onEach { messages ->
-                _uiState.value = _uiState.value.copy(messages = messages)
-            }.launchIn(viewModelScope)
+        loadData()
+    }
+
+    private fun loadData() {
+        viewModelScope.launch {
+            // 1. Set loading state and get current user ID
+            val currentUserId = getCurrentUserUseCase()?.uid ?: ""
+            _uiState.value = _uiState.value.copy(
+                isLoading = true,
+                currentUserId = currentUserId
+            )
+            Log.d("GlobalChatViewModel", "Current User ID set to: $currentUserId")
+
+
+            // 2. Fetch the list of users first.
+            getUsersUseCase().onSuccess { users ->
+                val userMap = users.associateBy({ it.uid }, { it.displayName })
+                Log.d("GlobalChatViewModel", "User Map Loaded: $userMap")
+
+                // 3. If users are fetched successfully, start listening for messages.
+                getGlobalMessagesUseCase().onEach { messages ->
+                    val uiMessages = messages.map { message ->
+                        UiMessage(
+                            message = message,
+                            senderDisplayName = userMap[message.senderId] ?: "Unknown User"
+                        )
+                    }
+                    _uiState.value = _uiState.value.copy(
+                        messages = uiMessages,
+                        isLoading = false // Turn off loading once we have messages
+                    )
+                }.catch { e ->
+                    Log.e("GlobalChatViewModel", "Error listening for messages", e)
+                    _uiState.value = _uiState.value.copy(error = e.message, isLoading = false)
+                }.launchIn(viewModelScope)
+
+            }.onFailure { e ->
+                Log.e("GlobalChatViewModel", "Error fetching users", e)
+                _uiState.value = _uiState.value.copy(error = e.message, isLoading = false)
+            }
+        }
     }
 
     fun onMessageChange(message: String) {


### PR DESCRIPTION
This commit introduces several improvements to the Global Chat screen:

- **Display Sender Names:** Messages from other users now show the sender's display name above the message bubble. This is achieved by:
    - Introducing a `UiMessage` data class in `GlobalChatState` that wraps the `Message` object and includes `senderDisplayName`.
    - Modifying `GlobalChatViewModel` to fetch a map of user IDs to display names using `GetUsersUseCase`.
    - Updating `GlobalChatViewModel` to populate `UiMessage` with the sender's display name when loading messages.
    - Updating `MessageBubble` composable to display the `senderDisplayName` if the message is not from the current user.

- **Loading Indicator:** A `CircularProgressIndicator` is now displayed while messages and user data are being fetched.
    - `GlobalChatState` now includes an `isLoading` boolean.
    - `GlobalChatViewModel` sets `isLoading` to true before fetching data and to false after data is loaded or an error occurs.
    - `GlobalChatScreen` conditionally displays the loading indicator based on the `isLoading` state.

- **Refactored Data Loading:** The data loading logic in `GlobalChatViewModel` has been refactored to:
    - First, set the loading state and current user ID.
    - Then, fetch the list of users.
    - If user fetching is successful, then listen for global messages and map them to `UiMessage` objects.
    - Error handling has been added for both user fetching and message listening.

- **Dependency Injection:** `GetUsersUseCase` is now injected into `GlobalChatViewModel`.