### PR TITLE
Implement message reactions

### DIFF
--- a/app/src/main/java/com/example/chatapp/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/com/example/chatapp/data/repository/ChatRepositoryImpl.kt
@@ -2,8 +2,10 @@ package com.example.chatapp.data.repository
 
 import com.example.chatapp.domain.ChatRepository
 import com.example.chatapp.domain.model.Message
+import com.example.chatapp.domain.model.Reaction
 import com.example.chatapp.domain.model.User
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import kotlinx.coroutines.channels.awaitClose
@@ -101,6 +103,53 @@ class ChatRepositoryImpl(
                 }
             }
         awaitClose { subscription.remove() }
+    }
+
+    override suspend fun toggleReactionOnPrivateMessage(
+        receiverId: String,
+        messageId: String,
+        reaction: Reaction
+    ): Result<Unit> {
+        val senderId = auth.currentUser?.uid ?: return Result.failure(Exception("User not logged in"))
+        val chatRoomId = getChatRoomId(senderId, receiverId)
+        val messageRef = firestore.collection("chats").document(chatRoomId).collection("messages").document(messageId)
+
+        return try {
+            firestore.runTransaction { transaction ->
+                val snapshot = transaction.get(messageRef)
+                val currentReactions = snapshot.get("reactions") as? Map<String, String> ?: emptyMap()
+
+                if (currentReactions[senderId] == reaction.key) {
+                    transaction.update(messageRef, "reactions.$senderId", FieldValue.delete())
+                } else {
+                    transaction.update(messageRef, "reactions.$senderId", reaction.key)
+                }
+            }.await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun toggleReactionOnGlobalMessage(messageId: String, reaction: Reaction): Result<Unit> {
+        val senderId = auth.currentUser?.uid ?: return Result.failure(Exception("User not logged in"))
+        val messageRef = firestore.collection("global_chat").document(messageId)
+
+        return try {
+            firestore.runTransaction { transaction ->
+                val snapshot = transaction.get(messageRef)
+                val currentReactions = snapshot.get("reactions") as? Map<String, String> ?: emptyMap()
+
+                if (currentReactions[senderId] == reaction.key) {
+                    transaction.update(messageRef, "reactions.$senderId", FieldValue.delete())
+                } else {
+                    transaction.update(messageRef, "reactions.$senderId", reaction.key)
+                }
+            }.await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
 

--- a/app/src/main/java/com/example/chatapp/di/domianModule.kt
+++ b/app/src/main/java/com/example/chatapp/di/domianModule.kt
@@ -10,6 +10,8 @@ import com.example.chatapp.domain.chatUseCases.GetGlobalMessagesUseCase
 import com.example.chatapp.domain.chatUseCases.GetUsersUseCase
 import com.example.chatapp.domain.chatUseCases.SendGlobalMessageUseCase
 import com.example.chatapp.domain.chatUseCases.SendMessageUseCase
+import com.example.chatapp.domain.chatUseCases.ToggleGlobalMessageReactionUseCase
+import com.example.chatapp.domain.chatUseCases.TogglePrivateMessageReactionUseCase
 import com.example.chatapp.domain.geminiUseCase.GetGeminiResponseUseCase
 import org.koin.dsl.module
 
@@ -30,4 +32,8 @@ val domainModule = module {
 
     //ai chat
     factory { GetGeminiResponseUseCase(get()) }
+
+    // Reactions
+    factory { TogglePrivateMessageReactionUseCase(get()) }
+    factory { ToggleGlobalMessageReactionUseCase(get()) }
 }

--- a/app/src/main/java/com/example/chatapp/di/presentationModule.kt
+++ b/app/src/main/java/com/example/chatapp/di/presentationModule.kt
@@ -16,8 +16,8 @@ val presentationModule = module {
     viewModel { ForgotPasswordViewModel(get()) }
     viewModel { UsersViewModel(get(), get(), get()) }
     // We pass parameters to ChatViewModel from the navigation graph
-    viewModel { params -> ChatViewModel(receiverId = params.get(), get(), get(), get()) }
-    viewModel { GlobalChatViewModel(get(), get(), get(), get()) }
+    viewModel { params -> ChatViewModel(receiverId = params.get(), get(), get(), get(), get()) }
+    viewModel { GlobalChatViewModel(get(), get(), get(), get(), get()) }
 
     viewModel { AiChatViewModel(get()) }
 }

--- a/app/src/main/java/com/example/chatapp/domain/ChatRepository.kt
+++ b/app/src/main/java/com/example/chatapp/domain/ChatRepository.kt
@@ -1,6 +1,7 @@
 package com.example.chatapp.domain
 
 import com.example.chatapp.domain.model.Message
+import com.example.chatapp.domain.model.Reaction
 import com.example.chatapp.domain.model.User
 import kotlinx.coroutines.flow.Flow
 
@@ -10,4 +11,9 @@ interface ChatRepository {
     fun getChatMessages(receiverId: String): Flow<List<Message>>
     suspend fun sendGlobalMessage(text: String): Result<Unit>
     fun getGlobalChatMessages(): Flow<List<Message>>
+
+    // New functions for handling reactions
+    suspend fun toggleReactionOnPrivateMessage(receiverId: String, messageId: String, reaction: Reaction): Result<Unit>
+    suspend fun toggleReactionOnGlobalMessage(messageId: String, reaction: Reaction): Result<Unit>
+
 }

--- a/app/src/main/java/com/example/chatapp/domain/chatUseCases/ToggleGlobalMessageReactionUseCase.kt
+++ b/app/src/main/java/com/example/chatapp/domain/chatUseCases/ToggleGlobalMessageReactionUseCase.kt
@@ -1,0 +1,9 @@
+package com.example.chatapp.domain.chatUseCases
+
+import com.example.chatapp.domain.ChatRepository
+import com.example.chatapp.domain.model.Reaction
+
+class ToggleGlobalMessageReactionUseCase(private val repository: ChatRepository) {
+    suspend operator fun invoke(messageId: String, reaction: Reaction) =
+        repository.toggleReactionOnGlobalMessage(messageId, reaction)
+}

--- a/app/src/main/java/com/example/chatapp/domain/chatUseCases/TogglePrivateMessageReactionUseCase.kt
+++ b/app/src/main/java/com/example/chatapp/domain/chatUseCases/TogglePrivateMessageReactionUseCase.kt
@@ -1,0 +1,9 @@
+package com.example.chatapp.domain.chatUseCases
+
+import com.example.chatapp.domain.ChatRepository
+import com.example.chatapp.domain.model.Reaction
+
+class TogglePrivateMessageReactionUseCase(private val repository: ChatRepository) {
+    suspend operator fun invoke(receiverId: String, messageId: String, reaction: Reaction) =
+        repository.toggleReactionOnPrivateMessage(receiverId, messageId, reaction)
+}

--- a/app/src/main/java/com/example/chatapp/domain/model/Message.kt
+++ b/app/src/main/java/com/example/chatapp/domain/model/Message.kt
@@ -5,5 +5,19 @@ data class Message(
     val senderId: String = "",
     val receiverId: String? = null,
     val text: String = "",
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long = System.currentTimeMillis(),
+    val reactions: Map<String, String> = emptyMap(),
 )
+
+enum class Reaction(val key: String, val emoji: String) {
+    LIKE("like", "👍"),
+    LOVE("love", "❤️"),
+    WOW("wow", "😮"),
+    SAD("sad", "😢"),
+    ANGRY("angry", "😠");
+
+    companion object {
+        // A helper to find a reaction by its key
+        fun fromKey(key: String?): Reaction? = entries.find { it.key == key }
+    }
+}

--- a/app/src/main/java/com/example/chatapp/presentation/chatScreen/ChatScreen.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/chatScreen/ChatScreen.kt
@@ -23,6 +23,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -30,8 +33,10 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.example.chatapp.presentation.components.ChatInput
 import com.example.chatapp.presentation.components.MessageBubble
+import com.example.chatapp.presentation.components.ReactionPalette
 import com.example.chatapp.presentation.globalChatScreen.UiMessage
 import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -39,11 +44,11 @@ fun ChatScreen(
     navController: NavController,
     receiverId: String,
     receiverName: String,
-    viewModel: ChatViewModel = koinViewModel(parameters = { org.koin.core.parameter.parametersOf(receiverId) })
+    viewModel: ChatViewModel = koinViewModel(parameters = { parametersOf(receiverId) })
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val listState = rememberLazyListState()
-
+    var selectedMessageId by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(uiState.messages.size) {
         if (uiState.messages.isNotEmpty()) {
@@ -54,9 +59,7 @@ fun ChatScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = {
-                    Text("Chat with $receiverName")
-                        },
+                title = { Text("Chat with $receiverName") },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -78,23 +81,41 @@ fun ChatScreen(
         },
         containerColor = Color.White
     ) { paddingValues ->
-        if (uiState.isLoading) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
+        Box(modifier = Modifier.fillMaxSize()) {
+            if (uiState.isLoading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            } else {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                        .padding(horizontal = 16.dp),
+                    contentPadding = PaddingValues(vertical = 8.dp)
+                ) {
+                    items(uiState.messages) { message ->
+                        MessageBubble(
+                            uiMessage = UiMessage(message, receiverName),
+                            isFromCurrentUser = message.senderId == uiState.currentUserId,
+                            onLongPress = { msgId -> selectedMessageId = msgId }
+                        )
+                    }
+                }
             }
-        } else {
-            LazyColumn(
-                state = listState,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .padding(horizontal = 16.dp),
-                contentPadding = PaddingValues(vertical = 8.dp)
-            ) {
-                items(uiState.messages) { uiMessage ->
-                    MessageBubble(
-                        uiMessage = UiMessage(uiMessage, receiverName),
-                        isFromCurrentUser = uiMessage.senderId == uiState.currentUserId
+
+            // Show Reaction Palette when a message is selected
+            if (selectedMessageId != null) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(bottom = 80.dp), // Adjust padding to avoid overlap with chat input
+                    contentAlignment = Alignment.BottomCenter
+                ) {
+                    ReactionPalette(
+                        onReactionSelected = { reaction ->
+                            viewModel.toggleReaction(selectedMessageId!!, reaction)
+                            selectedMessageId = null // Hide palette after selection
+                        }
                     )
                 }
             }

--- a/app/src/main/java/com/example/chatapp/presentation/chatScreen/ChatViewModel.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/chatScreen/ChatViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.example.chatapp.domain.authUseCases.GetCurrentUserUseCase
 import com.example.chatapp.domain.chatUseCases.GetChatMessagesUseCase
 import com.example.chatapp.domain.chatUseCases.SendMessageUseCase
+import com.example.chatapp.domain.chatUseCases.TogglePrivateMessageReactionUseCase
+import com.example.chatapp.domain.model.Reaction
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
@@ -15,7 +17,8 @@ class ChatViewModel(
     private val receiverId: String,
     private val getChatMessagesUseCase: GetChatMessagesUseCase,
     private val sendMessageUseCase: SendMessageUseCase,
-    private val getCurrentUserUseCase: GetCurrentUserUseCase
+    private val getCurrentUserUseCase: GetCurrentUserUseCase,
+    private val toggleReactionUseCase: TogglePrivateMessageReactionUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ChatState())
     val uiState = _uiState.asStateFlow()
@@ -39,6 +42,17 @@ class ChatViewModel(
                 sendMessageUseCase(receiverId, text)
                 _uiState.value = _uiState.value.copy(currentMessage = "") // Clear input
             }
+        }
+    }
+
+    fun toggleReaction(messageId: String, reaction: Reaction) {
+        viewModelScope.launch {
+            toggleReactionUseCase(
+                receiverId = receiverId,
+                messageId = messageId,
+                reaction = reaction
+            )
+            // No need to update state here, Firestore's snapshot listener will do it for us.
         }
     }
 }

--- a/app/src/main/java/com/example/chatapp/presentation/components/MessageBubble.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/components/MessageBubble.kt
@@ -1,6 +1,8 @@
 package com.example.chatapp.presentation.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,8 +11,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -19,13 +26,20 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.chatapp.domain.model.Reaction
 import com.example.chatapp.presentation.globalChatScreen.UiMessage
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
 @Composable
-fun MessageBubble(uiMessage: UiMessage, isFromCurrentUser: Boolean) {
+fun MessageBubble(
+    uiMessage: UiMessage,
+    isFromCurrentUser: Boolean,
+    onLongPress: (String) -> Unit, // Callback with messageId
+    modifier: Modifier = Modifier
+) {
     val alignment = if (isFromCurrentUser) Alignment.End else Alignment.Start
     val horizontalArrangement = if (isFromCurrentUser) Arrangement.End else Arrangement.Start
 
@@ -38,13 +52,12 @@ fun MessageBubble(uiMessage: UiMessage, isFromCurrentUser: Boolean) {
     }
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp),
         horizontalArrangement = horizontalArrangement
     ) {
         Column(horizontalAlignment = alignment) {
-            // Show sender's name for messages from other users
             if (!isFromCurrentUser) {
                 Text(
                     text = uiMessage.senderDisplayName,
@@ -57,16 +70,89 @@ fun MessageBubble(uiMessage: UiMessage, isFromCurrentUser: Boolean) {
                 modifier = Modifier
                     .clip(bubbleShape)
                     .background(backgroundColor)
+                    .combinedClickable(
+                        onClick = { /* Can add single click logic here later */ },
+                        onLongClick = { onLongPress(uiMessage.message.messageId) }
+                    )
                     .padding(horizontal = 16.dp, vertical = 10.dp)
             ) {
                 Text(text = uiMessage.message.text, color = textColor)
             }
+
+            // Display Reactions if they exist
+            if (uiMessage.message.reactions.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                ReactionsDisplay(reactions = uiMessage.message.reactions)
+            }
+
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = formatTimestamp(uiMessage.message.timestamp),
                 style = MaterialTheme.typography.bodySmall,
                 color = Color.Gray
             )
+        }
+    }
+}
+
+@Composable
+fun ReactionPalette(
+    onReactionSelected: (Reaction) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(24.dp),
+        shadowElevation = 8.dp,
+        color = MaterialTheme.colorScheme.surface
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Reaction.entries.forEach { reaction ->
+                Text(
+                    text = reaction.emoji,
+                    fontSize = 24.sp,
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .clickable { onReactionSelected(reaction) }
+                        .padding(6.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReactionsDisplay(reactions: Map<String, String>) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy((-8).dp), // Overlap emojis slightly
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val reactionCounts = reactions.values.groupingBy { it }.eachCount()
+        items(items = reactionCounts.entries.toList()) { (reactionKey, count) ->
+            val reaction = Reaction.fromKey(reactionKey)
+            if (reaction != null) {
+                Row(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.8f))
+                        .padding(horizontal = 6.dp, vertical = 2.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(text = reaction.emoji, fontSize = 14.sp)
+                    if (count > 1) {
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = count.toString(),
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatScreen.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatScreen.kt
@@ -23,6 +23,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -32,6 +35,7 @@ import androidx.navigation.NavController
 import com.example.chatapp.domain.model.Message
 import com.example.chatapp.presentation.components.ChatInput
 import com.example.chatapp.presentation.components.MessageBubble
+import com.example.chatapp.presentation.components.ReactionPalette
 import com.example.chatapp.ui.theme.ChatAppTheme
 import org.koin.androidx.compose.koinViewModel
 
@@ -43,6 +47,7 @@ fun GlobalChatScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val listState = rememberLazyListState()
+    var selectedMessageId by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(uiState.messages.size) {
         if (uiState.messages.isNotEmpty()) {
@@ -75,30 +80,47 @@ fun GlobalChatScreen(
         },
         containerColor = Color.White
     ) { paddingValues ->
-        if (uiState.isLoading) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
+        Box(modifier = Modifier.fillMaxSize()) {
+            if (uiState.isLoading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            } else {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                        .padding(horizontal = 16.dp),
+                    contentPadding = PaddingValues(vertical = 8.dp)
+                ) {
+                    items(uiState.messages) { uiMessage ->
+                        MessageBubble(
+                            uiMessage = uiMessage,
+                            isFromCurrentUser = uiMessage.message.senderId == uiState.currentUserId,
+                            onLongPress = { msgId -> selectedMessageId = msgId }
+                        )
+                    }
+                }
             }
-        } else {
-            LazyColumn(
-                state = listState,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .padding(horizontal = 16.dp),
-                contentPadding = PaddingValues(vertical = 8.dp)
-            ) {
-                items(uiState.messages) { uiMessage ->
-                    MessageBubble(
-                        uiMessage = uiMessage,
-                        isFromCurrentUser = uiMessage.message.senderId == uiState.currentUserId
+
+            // Show Reaction Palette when a message is selected
+            if (selectedMessageId != null) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(bottom = 80.dp), // Adjust padding to avoid overlap with chat input
+                    contentAlignment = Alignment.BottomCenter
+                ) {
+                    ReactionPalette(
+                        onReactionSelected = { reaction ->
+                            viewModel.toggleReaction(selectedMessageId!!, reaction)
+                            selectedMessageId = null // Hide palette after selection
+                        }
                     )
                 }
             }
         }
     }
 }
-
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview(showBackground = true)
@@ -136,7 +158,9 @@ fun GlobalChatScreenPreview() {
                 items(previewUiMessages) { uiMessage ->
                     MessageBubble(
                         uiMessage = uiMessage,
-                        isFromCurrentUser = uiMessage.message.senderId == "2" // "2" is the current user in this preview
+                        isFromCurrentUser = uiMessage.message.senderId == "2",
+                        onLongPress = {},
+                        modifier = Modifier.navigationBarsPadding() ,
                     )
                 }
             }

--- a/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatViewModel.kt
+++ b/app/src/main/java/com/example/chatapp/presentation/globalChatScreen/GlobalChatViewModel.kt
@@ -7,6 +7,8 @@ import com.example.chatapp.domain.authUseCases.GetCurrentUserUseCase
 import com.example.chatapp.domain.chatUseCases.GetGlobalMessagesUseCase
 import com.example.chatapp.domain.chatUseCases.GetUsersUseCase
 import com.example.chatapp.domain.chatUseCases.SendGlobalMessageUseCase
+import com.example.chatapp.domain.chatUseCases.ToggleGlobalMessageReactionUseCase
+import com.example.chatapp.domain.model.Reaction
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
@@ -18,7 +20,8 @@ class GlobalChatViewModel(
     private val getGlobalMessagesUseCase: GetGlobalMessagesUseCase,
     private val sendGlobalMessageUseCase: SendGlobalMessageUseCase,
     private val getCurrentUserUseCase: GetCurrentUserUseCase,
-    private val getUsersUseCase: GetUsersUseCase
+    private val getUsersUseCase: GetUsersUseCase,
+    private val toggleReactionUseCase: ToggleGlobalMessageReactionUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(GlobalChatState())
     val uiState = _uiState.asStateFlow()
@@ -78,6 +81,12 @@ class GlobalChatViewModel(
                 sendGlobalMessageUseCase(text)
                 _uiState.value = _uiState.value.copy(currentMessage = "") // Clear input
             }
+        }
+    }
+
+    fun toggleReaction(messageId: String, reaction: Reaction) {
+        viewModelScope.launch {
+            toggleReactionUseCase(messageId = messageId, reaction = reaction)
         }
     }
 }


### PR DESCRIPTION
This commit introduces the ability for users to react to messages in both private and global chats.

**New Domain Layer Components:**

*   **`Reaction` enum:** Defines available reactions (LIKE, LOVE, WOW, SAD, ANGRY) with their corresponding keys and emojis.
*   **`TogglePrivateMessageReactionUseCase`:** Use case to toggle a reaction on a private message.
*   **`ToggleGlobalMessageReactionUseCase`:** Use case to toggle a reaction on a global message.
*   The `domainModule` has been updated to provide these new use cases.

**Chat Repository Updates (`ChatRepository` and `ChatRepositoryImpl`):**

*   Added `toggleReactionOnPrivateMessage` and `toggleReactionOnGlobalMessage` methods to the `ChatRepository` interface.
*   Implemented these methods in `ChatRepositoryImpl` to:
    *   Use Firebase transactions to atomically update the `reactions` map on a message document.
    *   If the user has already reacted with the same emoji, the reaction is removed.
    *   Otherwise, the new reaction is added or updated.

**ViewModel Updates (`ChatViewModel`, `GlobalChatViewModel`):**

*   Both ViewModels now include a `toggleReaction` function that calls the respective use case.
*   They are injected with the new reaction toggle use cases.

**UI Changes:**

*   **`MessageBubble` Composable:**
    *   Now accepts an `onLongPress` callback which is triggered when a message is long-pressed, providing the `messageId`.
    *   Displays reactions below the message bubble using the new `ReactionsDisplay` Composable.
*   **`ReactionPalette` Composable:**
    *   A new Composable that displays a row of reaction emojis.
    *   Takes an `onReactionSelected` callback that is triggered when an emoji is tapped.
*   **`ReactionsDisplay` Composable:**
    *   A new private Composable within `MessageBubble.kt` to render the emojis and their counts for a given message's reactions.
*   **`ChatScreen` and `GlobalChatScreen`:**
    *   Manage a `selectedMessageId` state.
    *   When a message is long-pressed in `MessageBubble`, `selectedMessageId` is updated.
    *   If `selectedMessageId` is not null, the `ReactionPalette` is shown.
    *   When a reaction is selected from the palette, the corresponding ViewModel's `toggleReaction` function is called, and the palette is hidden.

**Data Model Update:**

*   **`Message` data class:** Added a `reactions` field (Map<String, String>) to store user IDs and their reaction keys.